### PR TITLE
add express types, fix error in /summary endpoint type signature

### DIFF
--- a/backend/autotester/package-lock.json
+++ b/backend/autotester/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "^22.13.1",
+        "@types/supertest": "^6.0.2",
         "jest": "^29.7.0",
         "supertest": "^7.0.0",
         "ts-node": "^10.9.2",
@@ -1041,6 +1042,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1084,6 +1092,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.13.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
@@ -1098,6 +1113,30 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
+      "integrity": "sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",

--- a/backend/autotester/package.json
+++ b/backend/autotester/package.json
@@ -5,7 +5,6 @@
     "test_part1": "jest -t \"Task 1\"",
     "test_part2": "jest -t \"Task 2\"",
     "test_part3": "jest -t \"Task 3\""
-
   },
   "dependencies": {
     "express": "^4.21.2"
@@ -13,6 +12,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.1",
+    "@types/supertest": "^6.0.2",
     "jest": "^29.7.0",
     "supertest": "^7.0.0",
     "ts-node": "^10.9.2",

--- a/backend/autotester/src/test.spec.ts
+++ b/backend/autotester/src/test.spec.ts
@@ -1,8 +1,8 @@
-const request = require("supertest");
+import request from "supertest";
 
 describe("Task 1", () => {
   describe("POST /parse", () => {
-    const getTask1 = async (inputStr) => {
+    const getTask1 = async (inputStr: string) => {
       return await request("http://localhost:8080")
         .post("/parse")
         .send({ input: inputStr });
@@ -27,7 +27,7 @@ describe("Task 1", () => {
 
 describe("Task 2", () => {
   describe("POST /entry", () => {
-    const putTask2 = async (data) => {
+    const putTask2 = async (data: string | object) => {
       return await request("http://localhost:8080").post("/entry").send(data);
     };
 
@@ -98,11 +98,11 @@ describe("Task 2", () => {
 
 describe("Task 3", () => {
   describe("GET /summary", () => {
-    const postEntry = async (data) => {
+    const postEntry = async (data: string | object) => {
       return await request("http://localhost:8080").post("/entry").send(data);
     };
 
-    const getTask3 = async (name) => {
+    const getTask3 = async (name: string) => {
       return await request("http://localhost:8080").get(
         `/summary?name=${name}`
       );

--- a/backend/autotester/src/test.spec.ts
+++ b/backend/autotester/src/test.spec.ts
@@ -2,7 +2,7 @@ import request from "supertest";
 
 describe("Task 1", () => {
   describe("POST /parse", () => {
-    const getTask1 = async (inputStr: string) => {
+    const getTask1 = async (inputStr) => {
       return await request("http://localhost:8080")
         .post("/parse")
         .send({ input: inputStr });
@@ -27,7 +27,7 @@ describe("Task 1", () => {
 
 describe("Task 2", () => {
   describe("POST /entry", () => {
-    const putTask2 = async (data: string | object) => {
+    const putTask2 = async (data) => {
       return await request("http://localhost:8080").post("/entry").send(data);
     };
 
@@ -98,11 +98,11 @@ describe("Task 2", () => {
 
 describe("Task 3", () => {
   describe("GET /summary", () => {
-    const postEntry = async (data: string | object) => {
+    const postEntry = async (data) => {
       return await request("http://localhost:8080").post("/entry").send(data);
     };
 
-    const getTask3 = async (name: string) => {
+    const getTask3 = async (name) => {
       return await request("http://localhost:8080").get(
         `/summary?name=${name}`
       );

--- a/backend/autotester/src/test.spec.ts
+++ b/backend/autotester/src/test.spec.ts
@@ -18,6 +18,26 @@ describe("Task 1", () => {
       expect(response.body).toStrictEqual({ msg: "Alpha Alfredo" });
     });
 
+    it("example3", async () => {
+      const response = await getTask1("  alpHa-alFRedo   ");
+      expect(response.body).toStrictEqual({ msg: "Alpha Alfredo" });
+    });
+
+    it("example4", async () => {
+      const response = await getTask1("Riz@z     RISO00tto!");
+      expect(response.body).toStrictEqual({ msg: "Rizz Risotto" });
+    });
+
+    it("example5", async () => {
+      const response = await getTask1("meatball");
+      expect(response.body).toStrictEqual({ msg: "Meatball" });
+    });
+
+    it("example6", async () => {
+      const response = await getTask1("@_%");
+      expect(response.status).toBe(400);
+    });
+
     it("error case", async () => {
       const response = await getTask1("");
       expect(response.status).toBe(400);
@@ -92,6 +112,19 @@ describe("Task 2", () => {
         cookTime: 8,
       });
       expect(resp3.status).toBe(400);
+    });
+
+    it("Unique required items", async () => {
+      const meatball = {
+        type: "recipe",
+        name: "Meatball",
+        requiredItems: [
+          { name: "Beef", quantity: 1 },
+          { name: "Beef", quantity: 1 },
+        ],
+      };
+      const resp1 = await putTask2(meatball);
+      expect(resp1.status).toBe(400);
     });
   });
 });

--- a/backend/autotester/src/test.spec.ts
+++ b/backend/autotester/src/test.spec.ts
@@ -1,4 +1,4 @@
-import request from "supertest";
+const request = require("supertest");
 
 describe("Task 1", () => {
   describe("POST /parse", () => {

--- a/backend/ts_template/devdonalds.ts
+++ b/backend/ts_template/devdonalds.ts
@@ -59,7 +59,7 @@ app.post("/entry", (req:Request, res:Response) => {
 
 // [TASK 3] ====================================================================
 // Endpoint that returns a summary of a recipe that corresponds to a query name
-app.get("/summary", (req:Request, res:Request) => {
+app.get("/summary", (req:Request, res:Response) => {
   // TODO: implement me
   res.status(500).send("not yet implemented!")
 

--- a/backend/ts_template/devdonalds.ts
+++ b/backend/ts_template/devdonalds.ts
@@ -29,21 +29,20 @@ app.use(express.json());
 const cookbook: any = null;
 
 // Task 1 helper (don't touch)
-app.post("/parse", (req:Request, res:Response) => {
+app.post("/parse", (req: Request, res: Response) => {
   const { input } = req.body;
 
-  const parsed_string = parse_handwriting(input)
+  const parsed_string = parse_handwriting(input);
   if (parsed_string == null) {
     res.status(400).send("this string is cooked");
     return;
-  } 
+  }
   res.json({ msg: parsed_string });
   return;
-  
 });
 
 // [TASK 1] ====================================================================
-// Takes in a recipeName and returns it in a form that 
+// Takes in a recipeName and returns it in a form that
 const parse_handwriting = (recipeName: string): string | null => {
   // TODO: implement me
   return recipeName
@@ -51,18 +50,16 @@ const parse_handwriting = (recipeName: string): string | null => {
 
 // [TASK 2] ====================================================================
 // Endpoint that adds a CookbookEntry to your magical cookbook
-app.post("/entry", (req:Request, res:Response) => {
+app.post("/entry", (req: Request, res: Response) => {
   // TODO: implement me
-  res.status(500).send("not yet implemented!")
-
+  res.status(500).send("not yet implemented!");
 });
 
 // [TASK 3] ====================================================================
 // Endpoint that returns a summary of a recipe that corresponds to a query name
-app.get("/summary", (req:Request, res:Response) => {
+app.get("/summary", (req: Request, res: Response) => {
   // TODO: implement me
-  res.status(500).send("not yet implemented!")
-
+  res.status(500).send("not yet implemented!");
 });
 
 // =============================================================================

--- a/backend/ts_template/devdonalds.ts
+++ b/backend/ts_template/devdonalds.ts
@@ -44,9 +44,15 @@ app.post("/parse", (req: Request, res: Response) => {
 // [TASK 1] ====================================================================
 // Takes in a recipeName and returns it in a form that
 const parse_handwriting = (recipeName: string): string | null => {
-  // TODO: implement me
-  return recipeName
-}
+  recipeName = recipeName
+    .replace(/[-_]/g, " ")
+    .replace(/[^a-zA-Z ]/g, "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (s) => s.toUpperCase());
+  return recipeName.length !== 0 ? recipeName : null;
+};
 
 // [TASK 2] ====================================================================
 // Endpoint that adds a CookbookEntry to your magical cookbook

--- a/backend/ts_template/package-lock.json
+++ b/backend/ts_template/package-lock.json
@@ -9,6 +9,7 @@
         "express": "^4.21.2"
       },
       "devDependencies": {
+        "@types/express": "^5.0.0",
         "@types/node": "^22.13.1",
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
@@ -76,6 +77,67 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
+      "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.13.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
@@ -83,6 +145,43 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/accepts": {

--- a/backend/ts_template/package.json
+++ b/backend/ts_template/package.json
@@ -7,6 +7,7 @@
     "express": "^4.21.2"
   },
   "devDependencies": {
+    "@types/express": "^5.0.0",
     "@types/node": "^22.13.1",
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1",


### PR DESCRIPTION
Added `@types/express` as a devDependency, fixed a type signature error that was discovered as a result (a `res` callback argument being given the type `Request` rather than `Response`).